### PR TITLE
dev dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* `tempfile` and `assert_cmd` no longer required for build
 * CLI version now matches `Cargo.toml` version
 
 ## [0.1.1](https://crates.io/crates/rtw/0.1.1) Dec 26, 2019

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 dirs = "2.0"
 chrono = { version = "0.4", features = ["serde"] }
-tempfile = "3"
 regex = "1"
+
+[dev-dependencies]
+tempfile = "3"
 assert_cmd = "0.12"


### PR DESCRIPTION
`tempfile` and `assert_cmd` no longer required for build