### PR TITLE
Fix CLI output for Windows 10

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,9 @@ fn main() -> anyhow::Result<()> {
         finished_activity_path,
     ));
 
+    if cfg!(windows) {
+        ansi_term::enable_ansi_support().unwrap_or(());
+    }
     let action = run(&matches, &clock)?;
     let mutation = dry_run_action(action, &service, &clock, &config)?;
     if matches.is_present("dry-run") {


### PR DESCRIPTION
Windows has support for ANSI terminal colors, but they need to be enabled, otherwise the output gets all garbled. ansi_term has a function ansi_term::enable_ansi_support() for this.

This pull request simply calls this function when rtw is running on Windows.